### PR TITLE
Adds profile_update to appAuth example

### DIFF
--- a/openidm-ui-enduser-appauth/README.md
+++ b/openidm-ui-enduser-appauth/README.md
@@ -165,6 +165,7 @@ curl 'http://am-service.sample.svc.cluster.local/openam/json/realms/root/realm-c
             "scopes": [
                 "openid",
                 "profile",
+                "profile_update",
                 "consent_read",
                 "workflow_tasks",
                 "notifications"
@@ -191,7 +192,7 @@ Alternatively you can add *appAuthClient* manually, utilizing the platform UI: [
     * "Client ID": "appAuthClient"
     * "Client type": "Public"
     * "Redirection URIs": ["http://localhost:8888/redirect.html"]
-    * "Scope(s)": ["openid", "profile", "consent_read", "workflow_tasks", "notifications"]
+    * "Scope(s)": ["openid", "profile", "profile_update", "consent_read", "workflow_tasks", "notifications"]
 * Click Save, then go to "Advanced"
     * "Token Endpoint Authentication Method": "client_secret_post"
 

--- a/openidm-ui-enduser-appauth/index.html
+++ b/openidm-ui-enduser-appauth/index.html
@@ -44,7 +44,7 @@
             "token_endpoint": "http://am-service.sample.svc.cluster.local:80/openam/oauth2/access_token",
             "revocation_endpoint": "http://am-service.sample.svc.cluster.local:80/openam/oauth2/token/revoke"
         }),
-        scopes: "openid profile consent_read workflow_tasks notifications",
+        scopes: "openid profile profile_update consent_read workflow_tasks notifications",
         notifier: new AppAuth.AuthorizationNotifier(),
         authorizationHandler: new AppAuth.RedirectRequestHandler(),
         tokenHandler: new AppAuth.BaseTokenRequestHandler()
@@ -86,7 +86,7 @@
                     {
                         "accessToken": "d5MqRg-2TWzxzQq76r7fkDtd0M8",
                         "idToken": "eyJ0eX......35uNGtw",
-                        "scope": "consent_read openid profile notifications workflow_tasks",
+                        "scope": "consent_read openid profile profile_update notifications workflow_tasks",
                         "tokenType": "Bearer",
                         "issuedAt": 1535666764,
                         "expiresIn": 3599


### PR DESCRIPTION
Works with the changes in PR here: https://github.com/ForgeRock/forgeops/pull/322

Allows the user to actually make changes to their profile. Previously they would simply be presented with failures.