### PR TITLE
Backport DX-4 Explain branches in the top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,20 @@ Each example client is self-contained, and fully described in its own README.
    https://github.com/ForgeRock/forgeops-init/tree/master/6.5/oauth2/development).
 1. Follow the README for your chosen client in this repository.
 
-Your browser does not trust the server certificates used by default.
-The certificates are signed by a self-signed example CA certificate.
-You can either trust the CA&mdash;temporarily, because the example CA keys are published&mdash;or
-use a browser that you can run with an option to skip server certificate validation,
-such as `google-chrome --ignore-certificate-errors https://login.sample.forgeops.com/console`.
+**Important**
+
+*   Match the branch versions of the `forgeops` and `exampleOAuth2Clients` repositories.<br>
+    _Different branches are not compatible and not interoperable._
+    The `master` branch is under active development. Older branches are more stable.
+    For example, before trying the `exampleOAuth2Clients` [6.5 branch](https://github.com/ForgeRock/exampleOAuth2Clients/tree/6.5),
+    check out a branch tracking the appropriate `forgeops` tag:
+    `cd forgeops ; git fetch --all --tags --prune ; git checkout tags/6.5.1 -b 6.5.1`<br>
+    The `forgeops-init` repository uses versioned directories rather than branches.
+*   Your browser does not trust the server certificates used by default.
+    The certificates are signed by a self-signed example CA certificate.
+    You can either trust the CA&mdash;temporarily, because the example CA keys are published&mdash;or
+    use a browser that you can run with an option to skip server certificate validation,
+    such as `google-chrome --ignore-certificate-errors https://login.sample.forgeops.com/console`
 
 ## About the Software
 


### PR DESCRIPTION
This patch adds another admonition to the README section on running
example clients: align `forgeops` and `exampleOAuth2Clients` branches.

This patch is a manual, but trivial, backport of 54a6e1a4bbf712cba2a75fb70e2013784eaad7b5 and 7d45f7da981c615a1e8d90264e89a5c7515917c2 where the different URL in the last line had to be preserved due to differences across branches.