### PR TITLE
DX-35 Avoid port clash with end user UI

### DIFF
--- a/basic-vertx/Dockerfile
+++ b/basic-vertx/Dockerfile
@@ -5,7 +5,7 @@ ENV VERTICLE_HOME /usr/verticles
 ENV VERTX_HOME /usr/local/vertx
 ENV VERTX_OPTS '-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 -Dvertx.disableFileCaching=true -Dvertx.disableFileCPResolving=true'
 
-EXPOSE 8888
+EXPOSE 18888
 EXPOSE 5005
 
 RUN wget http://central.maven.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar -O $VERTX_HOME/lib/slf4j-api-1.7.25.jar -q

--- a/basic-vertx/README.md
+++ b/basic-vertx/README.md
@@ -23,7 +23,7 @@ def authProvider = OAuth2Auth.create(vertx, OAuth2FlowType.AUTH_CODE, [
 
 router.route().handler(UserSessionHandler.create(authProvider))
 
-def oauth2Handler = OAuth2AuthHandler.create(authProvider, "http://localhost:8888")
+def oauth2Handler = OAuth2AuthHandler.create(authProvider, "http://localhost:18888")
 oauth2Handler.setupCallback(router.get("/callback"))
 
 // scopes we want to request during login
@@ -87,7 +87,7 @@ curl -k 'https://login.sample.forgeops.com/json/realms/root/realm-config/agents/
 -X PUT \
 --data '{
     "userpassword": "vertxClientSecret",
-    "redirectionUris": ["http://localhost:8888/callback"],
+    "redirectionUris": ["http://localhost:18888/callback"],
     "scopes": ["openid","profile"],
     "tokenEndpointAuthMethod": "client_secret_post"
 }' \
@@ -115,7 +115,7 @@ Browse to the [AM Console](https://login.sample.forgeops.com/console) and use th
 * Add new client:
     * "Client ID": "vertxClient"
     * "Client Secret": "vertxClientSecret"
-    * "Redirection URIs": ["http://localhost:8888/callback"]
+    * "Redirection URIs": ["http://localhost:18888/callback"]
     * "Scope(s)": ["openid", "profile"]
 * Click Save, then go to "Advanced"
     * "Token Endpoint Authentication Method": "client_secret_post"
@@ -127,7 +127,7 @@ The easiest way to execute this sample is by using Docker. This will automate th
 
 ```bash
 docker build -t basicvertxclient:latest .
-docker run -d -p 8888:8888 -p 5005:5005 basicvertxclient:latest
+docker run -d -p 18888:18888 -p 5005:5005 basicvertxclient:latest
 ```
 
 On Linux, you need to provide a separate flag (*--network host*) to get local host name resolution to work properly:
@@ -136,4 +136,4 @@ On Linux, you need to provide a separate flag (*--network host*) to get local ho
 docker run -d --network host basicvertxclient:latest
 ```
 
-Now you can access the application at <http://localhost:8888>.
+Now you can access the application at <http://localhost:18888>.

--- a/basic-vertx/src/app.groovy
+++ b/basic-vertx/src/app.groovy
@@ -37,7 +37,7 @@ def authProvider = OAuth2Auth.create(vertx, OAuth2FlowType.AUTH_CODE, opts)
 
 router.route().handler(UserSessionHandler.create(authProvider))
 
-def oauth2Handler = OAuth2AuthHandler.create(authProvider, "http://localhost:8888")
+def oauth2Handler = OAuth2AuthHandler.create(authProvider, "http://localhost:18888")
 oauth2Handler.setupCallback(router.get("/callback"))
 
 // scopes we want to request during login
@@ -86,4 +86,4 @@ def templateHandler = TemplateHandler.create(engine)
 router.get("/*").handler(templateHandler)
 
 def server  = vertx.createHttpServer()
-server.requestHandler( router .&'accept').listen(8888)
+server.requestHandler( router .&'accept').listen(18888)


### PR DESCRIPTION
This patch uses 18888 instead of 8888 for the Vert.x client as 8888 is
used by the end user UI.