### PR TITLE
DX-62: updated references to ForgeRock DevOps and Cloud Deployment sa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Each example client is self-contained, and fully described in its own README.
    * `skaffold` (<https://github.com/GoogleContainerTools/skaffold#installation>)
 1. (Optional) XCode on macOS for the iOS examples.
 1. Follow the README for the [ForgeRock Cloud Platform](
-   https://github.com/ForgeRock/forgeops/tree/master/dev)
+   https://github.com/ForgeRock/forgeops)
 1. Follow the README for your chosen client in this repository.
 
 **Important**
@@ -69,7 +69,7 @@ Each example client is self-contained, and fully described in its own README.
 
 To use the example client applications as described in their README files,
 you must access or set up a running instance of the ForgeRock
-[ForgeRock Cloud Platform](https://github.com/ForgeRock/forgeops/tree/master/dev).
+[ForgeRock Cloud Platform](https://github.com/ForgeRock/forgeops).
 The ForgeRock Cloud Platform deploys the ForgeRock Identity Platform
 into a Kubernetes environment such as `minikube` on a laptop,
 Amazon Elastic Container Service for Kubernetes (Amazon EKS), or

--- a/basic-vertx/README.md
+++ b/basic-vertx/README.md
@@ -78,7 +78,7 @@ The [app.groovy](src/app.groovy) code has the full context of these two snippets
 
 ### Prerequisites
 
-1. Install and run the [ForgeRock Cloud Platform](https://github.com/ForgeRock/forgeops/tree/master/dev).
+1. Install and run the [ForgeRock Cloud Platform](https://github.com/ForgeRock/forgeops).
 
 2. Register *vertxClient* application with AM as a new OAuth2 Client:
 

--- a/iOS-AppAuth/README.md
+++ b/iOS-AppAuth/README.md
@@ -1660,13 +1660,13 @@ We will build the app in a few implementation steps:
 
 [Back to top](#top)
 
-The ForgeRock platform provides server ingredients for setting up OAuth 2.0 flows: [ForgeRock Access Management](https://www.forgerock.com/platform/access-management) plays the role of the [OpenID Provider](https://openid.net/specs/openid-connect-core-1_0.html#Terminology) and [ForgeRock Identity Management](https://www.forgerock.com/platform/identity-management) may serve as the [Resource Server](https://tools.ietf.org/html/rfc6749#section-1.1). The easiest way to see it in action is setting up and running the [ForgeRock platform tailored for OAuth 2.0 development](https://github.com/ForgeRock/forgeops/tree/master/dev). With this environment in place, you will be able to evaluate a more advanced OAuth 2.0 client for iOS built by following the same principles as the basic application described above and, in fact, having the latter used as the starting point. The complete example could be found at [https://github.com/ForgeRock/exampleOAuth2Clients/tree/master/iOS-AppAuth/iOS-AppAuth-IDM](https://github.com/ForgeRock/exampleOAuth2Clients/tree/master/iOS-AppAuth/iOS-AppAuth-IDM). A [short video](https://forgerock.wistia.com/medias/3dft2ndyvh) demonstrates the app running on an iOS simulator.
+The ForgeRock platform provides server ingredients for setting up OAuth 2.0 flows: [ForgeRock Access Management](https://www.forgerock.com/platform/access-management) plays the role of the [OpenID Provider](https://openid.net/specs/openid-connect-core-1_0.html#Terminology) and [ForgeRock Identity Management](https://www.forgerock.com/platform/identity-management) may serve as the [Resource Server](https://tools.ietf.org/html/rfc6749#section-1.1). The easiest way to see it in action is setting up and running the [ForgeRock DevOps and Cloud Deployment sample](https://github.com/ForgeRock/forgeops). With this environment in place, you will be able to evaluate a more advanced OAuth 2.0 client for iOS built by following the same principles as the basic application described above and, in fact, having the latter used as the starting point. The complete example could be found at [https://github.com/ForgeRock/exampleOAuth2Clients/tree/master/iOS-AppAuth/iOS-AppAuth-IDM](https://github.com/ForgeRock/exampleOAuth2Clients/tree/master/iOS-AppAuth/iOS-AppAuth-IDM). A [short video](https://forgerock.wistia.com/medias/3dft2ndyvh) demonstrates the app running on an iOS simulator.
 
 This example assumes an instance of the ForgeRock platform running locally, within [Minikube](https://kubernetes.io/docs/setup/minikube/).
 
 ### Prerequisites
 
-0. Install and run the [ForgeRock Platform sample](https://github.com/ForgeRock/forgeops/tree/master/dev)
+0. Install and run the [ForgeRock Platform sample](https://github.com/ForgeRock/forgeops)
 
 ### Installing and running the application
 

--- a/node-passport-openidconnect/README.md
+++ b/node-passport-openidconnect/README.md
@@ -478,7 +478,7 @@ This web application was started with the [Express application generator](https:
 
 ### Prerequisites
 
-0. Install and run the [ForgeRock Cloud Platform](https://github.com/ForgeRock/forgeops/tree/master/dev).
+0. Install and run the [ForgeRock Cloud Platform](https://github.com/ForgeRock/forgeops).
 
 ### Installing and Running the Application
 

--- a/openidm-ui-enduser-jso/README.md
+++ b/openidm-ui-enduser-jso/README.md
@@ -154,7 +154,7 @@ The following illustrates how an SPA application can employ the Implicit flow ag
 
 ### Prerequisites
 
-0. Install and run the [ForgeRock Cloud Platform](https://github.com/ForgeRock/forgeops/tree/master/dev)
+0. Install and run the [ForgeRock Cloud Platform](https://github.com/ForgeRock/forgeops)
 
 ### Installing and Running the Application
 

--- a/spa-appauth/README.md
+++ b/spa-appauth/README.md
@@ -89,7 +89,7 @@ Once the tokens are available, the main SPA code can be loaded. This is what is 
 
 ### Prerequisites
 
-1. Install and run the [ForgeRock Cloud Platform](https://github.com/ForgeRock/forgeops/tree/master/dev).
+1. Install and run the [ForgeRock Cloud Platform](https://github.com/ForgeRock/forgeops).
 
 2. Register the *appAuthClient* application with AM as a new OAuth2 Client.
 


### PR DESCRIPTION
The references to the current ForgeRock DevOps and Cloud Deployment platform sample have been updated to reflect structural changes in forgeops—the `/dev` folder been moved to the top level. 