### PR TITLE
DX-62: corrections and fixed typos

### DIFF
--- a/iOS-AppAuth/README.md
+++ b/iOS-AppAuth/README.md
@@ -66,7 +66,7 @@ Recommendations for OAuth 2.0 implementation in Native Apps are summarized in [R
 
     The particularities of the iOS environment, combined with the fact that some identity providers allow for saving the user's consent and not asking for it again, mean that a consistent implementation of a mandatory consent screen may prove infeasible.
 
-    Consequently, Universal Links are currently the only reliable and generic way of confirming the client identity in iOS. Unfortunately, Universal Links are not very well suited for OAuth 2.0 redirection flows at the moment. They do not appear to work with HTTP redirects in iOS 10 and below and [seem to require an intermediate screen in front of the authorization endpoint](https://openradar.appspot.com/51091611) in iOS 11 and 12. The authorization server consent dialog may serve the role of such screen, making it a mandatory addition to the technique in the contemporary iOS environment. Combined with use of refresh tokens, this may constitute an acceptable end-user experience, although, for mobile applications developed by the same business entity as the one they are authorized by and consume resources from, the "first-party" clients, any consent screen may seem redundant and distracting.
+    Consequently, Universal Links are currently the only reliable and generic way of confirming the client identity in iOS. Unfortunately, Universal Links are not very well suited for OAuth 2.0 redirection flows at the moment. At present, they do not appear to work with HTTP redirects in iOS 9 and [seem to require an intermediate screen in front of the authorization endpoint](https://openradar.appspot.com/51091611) in iOS 10-12. The authorization server consent dialog may serve the role of such screen, making it a mandatory addition to the technique in the contemporary iOS environment. Combined with use of refresh tokens, this may constitute an acceptable end-user experience, although, for mobile applications developed by the same business entity as the one they are authorized by and consume resources from, the "first-party" clients, any consent screen may seem redundant and distracting.
 
 The included example iOS applications play the role of an [OpenID Connect](https://openid.net/connect/) (OIDC) [Relying Party](https://openid.net/specs/openid-connect-core-1_0.html#Terminology) (RP) and use the [AppAuth-iOS SDK](https://github.com/openid/AppAuth-iOS) for authorizing the RP against an [OIDC Provider](https://openid.net/specs/openid-connect-core-1_0.html#Terminology) (OP). The AppAuth SDK follows the best practices described in RFC 8252 by extending the OAuth 2.0 protocol with PKCE and employing an external user agent for visiting the OP's authentication and authorization endpoints. An access token obtained during the authorization process is then included as the [Bearer Token](https://tools.ietf.org/html/rfc6750) value of the `Authorization` header in requests made to protected endpoints on a [Resource Server](https://tools.ietf.org/html/rfc6749#section-1.1) (RS).
 
@@ -1324,7 +1324,7 @@ We will build the app in a few implementation steps:
 
                 This value is provided separately so that its presence in `Info.plist` can be easily checked and so that it can be reused with different redirection URIs.
                 */
-                let redirectionUriScheme = "https" // com.forgeops.ios-appauth-basic"
+                let redirectionUriScheme = "https" // "com.forgeops.ios-appauth-basic"
 
                 // . . .
 

--- a/iOS-AppAuth/iOS-AppAuth-Basic/iOS-AppAuth-Basic/ViewController.swift
+++ b/iOS-AppAuth/iOS-AppAuth-Basic/iOS-AppAuth-Basic/ViewController.swift
@@ -49,7 +49,7 @@ class ViewController: UIViewController {
 
      This value is provided separately so that its presence in `Info.plist` can be easily checked and so that it can be reused with different redirection URIs.
      */
-    let redirectionUriScheme = "https" // com.forgeops.ios-appauth-basic"
+    let redirectionUriScheme = "https" // "com.forgeops.ios-appauth-basic"
 
     /**
      OAuth 2 redirection URI for the client.

--- a/iOS-AppAuth/iOS-AppAuth-IDM/Source/UserNotifications.swift
+++ b/iOS-AppAuth/iOS-AppAuth-IDM/Source/UserNotifications.swift
@@ -19,8 +19,10 @@ struct UserNotifications {
             let _id: String?
         }
 
-        var notifications: [Notification] = []
+        var _notifications: [Notification] = []
     }
 
-    let url = "https://default.iam.example.com/openidm/endpoint/usernotifications/"
+    let url = "https://default.iam.example.com/openidm/managed/user/"
+    let urlQuery = "?_fields=_notifications/*"
+    let deleteUrl = "https://default.iam.example.com/openidm/internal/notification/"
 }

--- a/iOS-AppAuth/iOS-AppAuth-IDM/Source/ViewController.swift
+++ b/iOS-AppAuth/iOS-AppAuth-IDM/Source/ViewController.swift
@@ -685,7 +685,7 @@ extension ViewController {
                         vc.getNotifications = {
                             [unowned self] (completion) in
 
-                            self.makeUrlRequest(url: UserNotifications().url, protected: true) {
+                            self.makeUrlRequest(url: UserNotifications().url + (userLoginResponse?.authorization?.id ?? "") + UserNotifications().urlQuery, protected: true) {
                                 data, response, error, request in
 
                                 guard let json = self.decodeJson(UserNotifications.Response.self, from: data!) else {
@@ -694,7 +694,7 @@ extension ViewController {
                                     return
                                 }
 
-                                completion(json.notifications)
+                                completion(json._notifications)
                             }
                         }
 
@@ -702,7 +702,7 @@ extension ViewController {
                             [unowned self] (notificationId, completion) in
 
                             self.makeUrlRequest(
-                                url: UserNotifications().url + (notificationId ?? ""),
+                                url: UserNotifications().deleteUrl + (notificationId ?? ""),
                                 method: "DELETE",
                                 protected: true
                             ) {

--- a/node-passport-openidconnect/README.md
+++ b/node-passport-openidconnect/README.md
@@ -499,7 +499,7 @@ This web application was started with the [Express application generator](https:
           "userpassword": "password",
           "clientType": "Confidential",
           "redirectionUris": ["http://localhost:3000/forgerock/redirect"],
-          "scopes": ["openid", "fr:idm:profile", "fr:idm:consent_read", "fr:idm:notifications"],
+          "scopes": ["openid", "profile", "fr:idm:profile", "fr:idm:consent_read", "fr:idm:notifications"],
           "responseTypes": ["code"],
           "tokenEndpointAuthMethod": "client_secret_post",
           "isConsentImplied": false,
@@ -532,7 +532,7 @@ This web application was started with the [Express application generator](https:
           * "Client ID": "node-passport-openidconnect"
           * "Client secret": "password"
           * "Redirection URIs": ["http://localhost:3000/forgerock/redirect"]
-          * "Scope(s)": ["openid", "fr:idm:profile", "fr:idm:consent_read", "fr:idm:notifications"]
+          * "Scope(s)": ["openid", "profile", "fr:idm:profile", "fr:idm:consent_read", "fr:idm:notifications"]
       * Update the new client
           * _Core_ > "Client type": "Confidential"
           * _Advanced_ > "Response Types": ["code"]

--- a/node-passport-openidconnect/forgerock/client-config.js
+++ b/node-passport-openidconnect/forgerock/client-config.js
@@ -4,7 +4,7 @@ var config = {
     client_id: 'node-passport-openidconnect',
     client_secret: 'password',
     callbackURL: '/forgerock/redirect',
-    scope: 'openid fr:idm:profile fr:idm:consent_read fr:idm:notifications'
+    scope: 'openid profile fr:idm:profile fr:idm:consent_read fr:idm:notifications'
   }
 };
 


### PR DESCRIPTION
A few corrections in Node and iOS samples; in the former case, a necessary scope was missing in the OAuth 2.0 client and the corresponding Passport strategy setup to work with the latest forgeops.