### PR TITLE
Updated Dockerfile

### DIFF
--- a/node-passport-openidconnect/Dockerfile
+++ b/node-passport-openidconnect/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-slim
+FROM node:10-slim
 
 WORKDIR .
 


### PR DESCRIPTION
The image node:8-slim is no longer available on Docker hub. Updated this to use node:10-slim instead, which is also compatible with this project.